### PR TITLE
Initial skeleton of command lines.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,8 @@ edition = "2018"
 
 [dependencies]
 clap = "2.33.0"
+whoami = "0.5.2"
+
+
+[features]
+cli-test = []

--- a/bin/test-cli
+++ b/bin/test-cli
@@ -1,0 +1,127 @@
+#!/bin/sh -eu
+
+
+cargo build --features cli-test
+
+test_smith() {
+    unset SMITH_CLI_ENVIRONMENT SMITH_CLI_PRINCIPAL SMITH_CLI_COMMAND
+    ./target/debug/smith "$@" > /dev/null
+    eval $(./target/debug/smith "$@")
+}
+
+echo "-- smith --"
+
+echo 'testing: no arguments'
+! ./target/debug/smith 2>/dev/null
+
+echo 'testing: missing environment'
+! ./target/debug/smith -p root  2>/dev/null
+
+echo 'testing: bad flag'
+! ./target/debug/smith --bad -e environment -p root  2>/dev/null
+
+echo 'testing: all flag, no command'
+test_smith -e red -p jill
+[ "$SMITH_CLI_ENVIRONMENT" = "red" ]
+[ "$SMITH_CLI_PRINCIPAL" = "jill" ]
+[ -z "${SMITH_CLI_COMMAND:-}" ]
+
+echo 'testing: long flag, no command'
+test_smith --environment red-long --principal jill-long
+[ "$SMITH_CLI_ENVIRONMENT" = "red-long" ]
+[ "$SMITH_CLI_PRINCIPAL" = "jill-long" ]
+[ -z "${SMITH_CLI_COMMAND:-}" ]
+
+
+echo 'testing: default principal'
+test_smith -e blue
+[ "$SMITH_CLI_ENVIRONMENT" = "blue" ]
+[ "$SMITH_CLI_PRINCIPAL" = "$USER" ]
+[ -z "${SMITH_CLI_COMMAND:-}" ]
+
+
+echo 'testing: default principal + environment from environment'
+SMITH_ENVIRONMENT=yellow test_smith
+[ "$SMITH_CLI_ENVIRONMENT" = "yellow" ]
+[ "$SMITH_CLI_PRINCIPAL" = "$USER" ]
+[ -z "${SMITH_CLI_COMMAND:-}" ]
+
+
+echo 'testing: explicit command'
+SMITH_ENVIRONMENT=pink test_smith some command
+[ "$SMITH_CLI_ENVIRONMENT" = "pink" ]
+[ "$SMITH_CLI_PRINCIPAL" = "$USER" ]
+[ "$SMITH_CLI_COMMAND" = "some command" ]
+
+
+echo 'testing: explicit command with flag'
+SMITH_ENVIRONMENT=green test_smith some command -- --with-flag
+[ "$SMITH_CLI_ENVIRONMENT" = "green" ]
+[ "$SMITH_CLI_PRINCIPAL" = "$USER" ]
+[ "$SMITH_CLI_COMMAND" = "some command --with-flag" ]
+
+
+echo 'testing: explicit command and environment'
+SMITH_ENVIRONMENT=green test_smith -e orange some command -- --with-flag
+[ "$SMITH_CLI_ENVIRONMENT" = "orange" ]
+[ "$SMITH_CLI_PRINCIPAL" = "$USER" ]
+[ "$SMITH_CLI_COMMAND" = "some command --with-flag" ]
+
+
+echo "OK"
+
+test_smith_host() {
+    unset SMITH_CLI_ENVIRONMENT SMITH_CLI_CA_OUTPUT
+    ./target/debug/smith-host "$@" > /dev/null
+    eval $(./target/debug/smith-host "$@")
+}
+
+echo "-- smith-host --"
+
+echo 'testing: no arguments'
+! ./target/debug/smith-host 2>/dev/null
+
+echo 'testing: missing environment'
+! ./target/debug/smith-host  2>/dev/null
+
+echo 'testing: bad flag'
+! ./target/debug/smith-host --bad -e environment 2>/dev/null
+
+echo 'testing: environment flag, no output file'
+test_smith_host -e red
+[ "$SMITH_CLI_ENVIRONMENT" = "red" ]
+[ -z "${SMITH_CLI_CA_OUTPUT:-}" ]
+
+echo 'testing: environment from environment, no output file'
+SMITH_ENVIRONMENT=blue test_smith_host
+[ "$SMITH_CLI_ENVIRONMENT" = "blue" ]
+[ -z "${SMITH_CLI_CA_OUTPUT:-}" ]
+
+
+echo 'testing: environment flag, with output file'
+test_smith_host -e green output-file
+[ "$SMITH_CLI_ENVIRONMENT" = "green" ]
+[ "$SMITH_CLI_CA_OUTPUT" = "output-file" ]
+
+
+echo 'testing: environment long flag, with output file'
+test_smith_host --environment green-long output-file
+[ "$SMITH_CLI_ENVIRONMENT" = "green-long" ]
+[ "$SMITH_CLI_CA_OUTPUT" = "output-file" ]
+
+
+echo 'testing: environment from environment, with output file'
+SMITH_ENVIRONMENT=pink test_smith_host output-file
+[ "$SMITH_CLI_ENVIRONMENT" = "pink" ]
+[ "$SMITH_CLI_CA_OUTPUT" = "output-file" ]
+
+
+echo 'testing: environment from environment, with hyphen prefixed output file'
+test_smith_host -e orange -- -output-file
+[ "$SMITH_CLI_ENVIRONMENT" = "orange" ]
+[ "$SMITH_CLI_CA_OUTPUT" = "-output-file" ]
+
+
+echo "OK"
+
+rm -f target/debug/smith  target/debug/smith-host

--- a/src/bin/smith-host.rs
+++ b/src/bin/smith-host.rs
@@ -1,0 +1,39 @@
+extern crate smith;
+
+use clap::{App, AppSettings, Arg};
+
+fn main() {
+    let matches = App::new("smith-host")
+	.version(&smith::version::smith_version()[..])
+	.about("Fetch certificate-authority public keys for smith managed hosts.")
+	.setting(AppSettings::ArgRequiredElseHelp)
+	.arg(Arg::with_name("ENVIRONMENT")
+	     .short("e")
+	     .long("environment")
+	     .help("The environment to fetch public keys for.")
+	     .env("SMITH_ENVIRONMENT")
+             .value_name("ENVIRONMENT")
+	     .required(true))
+	.arg(Arg::with_name("FILE")
+             .help("Output path for certificate authority public keys file.")
+	     .required(false))
+	.get_matches();
+
+    let environment = matches.value_of("ENVIRONMENT").unwrap_or_else(|| {
+        eprintln!("Problem parsing arguments, no ENVIRONMENT specified.");
+        std::process::exit(1);
+    });
+
+    let file = matches.value_of("FILE");
+
+    if cfg!(feature = "cli-test") {
+        println!("SMITH_CLI_ENVIRONMENT='{}'", environment);
+        if let Some(file) = file {
+            println!("SMITH_CLI_CA_OUTPUT='{}'", file);
+        }
+        std::process::exit(0)
+    }
+
+    eprintln!("Not implemented yet.");
+    std::process::exit(1)
+}

--- a/src/bin/smith.rs
+++ b/src/bin/smith.rs
@@ -1,0 +1,51 @@
+extern crate clap;
+extern crate smith;
+extern crate whoami;
+
+use clap::{App, AppSettings, Arg};
+
+fn main() {
+    let matches = App::new("smith")
+	.version(&smith::version::smith_version()[..])
+	.about("Request short-lived certificate from smith.")
+	.setting(AppSettings::ArgRequiredElseHelp)
+	.arg(Arg::with_name("ENVIRONMENT")
+	     .short("e")
+	     .long("environment")
+	     .help("The environment to fetch public keys for.")
+	     .env("SMITH_ENVIRONMENT")
+             .value_name("ENVIRONMENT")
+	     .required(true))
+	.arg(Arg::with_name("PRINCIPAL")
+	     .short("p")
+	     .long("principal")
+	     .help("The principal to issue the key for.")
+	     .env("SMITH_PRINCIPAL")
+             .value_name("PRINCIPAL")
+	     .required(false))
+	.arg(Arg::from_usage("<CMD>... 'The command to run with configured ssh-agent.'")
+	     .required(false))
+	.get_matches();
+
+    let environment = matches.value_of("ENVIRONMENT").unwrap_or_else(|| {
+        eprintln!("Problem parsing arguments, no ENVIRONMENT specified.");
+        std::process::exit(1);
+    });
+
+    let principal = matches.value_of("PRINCIPAL").map(|p| p.to_string()).unwrap_or(whoami::username());
+
+    let cmd = matches.values_of("CMD");
+
+    if cfg!(feature = "cli-test") {
+        println!("SMITH_CLI_ENVIRONMENT='{}'", environment);
+        println!("SMITH_CLI_PRINCIPAL='{}'", principal);
+        if let Some(cmd) = cmd {
+            let cmd = cmd.into_iter().collect::<Vec<&str>>().join(" ");
+            println!("SMITH_CLI_COMMAND='{}'", cmd);
+        }
+        std::process::exit(0)
+    }
+
+    eprintln!("Not implemented yet.");
+    std::process::exit(1)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod version;
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,10 @@
+pub fn smith_version() -> String {
+    let version = format!(
+        "{}.{}.{}{}",
+        env!("CARGO_PKG_VERSION_MAJOR"),
+        env!("CARGO_PKG_VERSION_MINOR"),
+        env!("CARGO_PKG_VERSION_PATCH"),
+        option_env!("CARGO_PKG_VERSION_PRE").unwrap_or("")
+    );
+    return version;
+}


### PR DESCRIPTION
Testing inline to verify they are compatible with the haskell versions. May not be necessary to make them identicall, but will serve as a good regression test for cli anyway.